### PR TITLE
Support trusty and create directory

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
         - jessie
     - name: Ubuntu
       versions:
+        - trusty
         - xenial
     - name: EL
       version:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,16 @@
     dest: /tmp/{{couchdb_tgz}}
     mode: 0644
 
+- name: create directory
+  file:
+    path: '{{ item }}'
+    state: directory
+    mode: 0755
+  become: yes
+  become_user: root
+  with_items:
+    - '{{couchdb_parent_srcs_dir}}'
+
 - name: unarchive...
   become: yes
   become_user: root


### PR DESCRIPTION
@andrewrothstein I think the directory doesn't get created if you have it in a nested directory where the parent hasn't been created yet