### PR TITLE
Add 2.3.1 to couchdb_checksums

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,8 @@ couchdb_checksums:
   '2.1.1': sha256:d5f255abc871ac44f30517e68c7b30d1503ec0f6453267d641e00452c04e7bcc
   # https://www.apache.org/dist/couchdb/source/2.2.0/apache-couchdb-2.2.0.tar.gz.sha256
   '2.2.0': sha256:0e3ceb8aab73af8e54a2e2c949f362495b1c938455a15e9a4e294901c6c67985
+  # https://www.apache.org/dist/couchdb/source/2.3.1/apache-couchdb-2.3.1.tar.gz.sha256
+  '2.3.1': sha256:43eb8cec41eb52871bf22d35f3e2c2ce5b806ebdbce3594cf6b0438f2534227d
 
 couchdb_install_parent_dir: /usr/local
 couchdb_parent_srcs_dir: /usr/local/src


### PR DESCRIPTION
@andrewrothstein Is this all you might expect to be necessary to support a new 2.x version? I'll of course give it a run, but if you as the maintainer know of anything obvious, I'll take the guidance :)